### PR TITLE
Support provider inheritance

### DIFF
--- a/syringe.py
+++ b/syringe.py
@@ -108,9 +108,11 @@ def provides(name):
 
     """
     def inner(cls):
+        cls.__provides = name
         init = cls.__init__
 
         def __init__(self, *args, **kwargs):
+            name = type(self).__provides
             if name in _PROVIDERS:
                 raise DuplicateProviderError(
                     'A provider for [{}] already exists'.format(name))

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -68,6 +68,24 @@ class TestProvides(unittest.TestCase):
         self.assertEqual('A provider for [mock] already exists',
                          e.exception.args[0])
 
+    def test_provide_subclass_no_duplicate(self):
+        """
+        Test that a subclass is not marked as a duplicate.
+
+        """
+        @syringe.provides('A')
+        class A(object):
+            pass
+
+        @syringe.provides('B')
+        class B(A):
+            pass
+
+        a = A()
+        b = B()
+        self.assertIs(syringe.get('A'), a)
+        self.assertIs(syringe.get('B'), b)
+
 
 class TestGet(unittest.TestCase):
     """


### PR DESCRIPTION
When inheriting from a provider, the subclass should not be reported as a duplicate provider. This patch fixes that.

A badly named init file is also renamed.